### PR TITLE
Fix mobile layout for question actions

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -75,6 +75,12 @@ h1, h2 {
     margin-right: 10px;
 }
 
+.question-actions {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+}
+
 .question-votes {
     font-weight: bold;
     background-color: #e9ecef;


### PR DESCRIPTION
## Summary
- keep vote count and action buttons from wrapping on small screens

## Testing
- `python -m py_compile app.py`