### PR TITLE
Protect all pages via login

### DIFF
--- a/app.py
+++ b/app.py
@@ -129,11 +129,13 @@ def upvote_question(question_id):
 
 # --- Serve a Simple Test Page (Optional - for basic testing) ---
 @app.route('/')
+@login_required
 def index():
     """Serves the audience view."""
     return render_template('index.html', presenter=False)
 
 @app.route('/present/')
+@login_required
 def presenter_view():
     """Serves the presenter view with additional controls."""
     return render_template('index.html', presenter=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
         </div>
         {% if not presenter %}
         <p class="switch-link"><a href="{{ url_for('presenter_view') }}">Switch to Presenter</a>
-            {% if session.get('user') %}| <a href="{{ url_for('logout') }}">Logout</a>{% else %}| <a href="{{ url_for('login') }}">Admin Login</a>{% endif %}
+            {% if session.get('user') %}| <a href="{{ url_for('logout') }}">Logout</a>{% endif %}
         </p>
         {% else %}
         <p class="switch-link"><a href="{{ url_for('index') }}">Back to Audience</a>


### PR DESCRIPTION
## Summary
- require authentication for audience and presenter pages
- remove `Admin Login` link from index template

## Testing
- `python -m py_compile app.py`