### PR TITLE
Fix Ask Question button layout on small screens

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -25,6 +25,7 @@ h1, h2 {
 
 .input-section form {
     display: flex;
+    flex-wrap: wrap; /* Allow elements to wrap on narrow screens */
     margin-bottom: 10px;
 }
 
@@ -181,4 +182,13 @@ h1, h2 {
 
 .admin-button:hover {
     opacity: 0.9;
+}
+
+/* Adjust layout for narrow screens */
+@media (max-width: 500px) {
+    .input-section button {
+        margin-left: 0;
+        margin-top: 10px;
+        flex-basis: 100%; /* Place button on its own line */
+    }
 }


### PR DESCRIPTION
## Summary
- allow the form controls to wrap
- move "Ask Question" button onto its own line when the screen is narrow

## Testing
- `pytest -q`
- `python -m py_compile app.py config.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_b_683b88e213cc8323a17ce0f84cb425ec